### PR TITLE
New coverage method

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,0 @@
-repo_token: XPzmrHhoYrzmNKQwNRGXzoFqpkGNVbVLb

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Upgrading
 Using
 web
 npm-debug.log
+coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: node_js
 node_js:
   - "6"
 deploy:
-  provider: pages
   skip_cleanup: true
   github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
   on:
     branch: dev
-after_success: npm run coverage
+script: "npm run-script test-travis"
+after_script: "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha",
-    "coverage": "./node_modules/.bin/nyc report --reporter=text-lcov | coveralls"
+    "test-travis": "./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha"
   },
   "author": "",
   "license": "ISC",
@@ -22,8 +22,7 @@
     "coveralls": "^2.13.1",
     "heroku-cli-util": "*",
     "mocha": "*",
-    "mocha-lcov-reporter": "^1.3.0",
-    "nyc": "^11.0.3",
+    "istanbul": "*",
     "sinon": "*"
   },
   "directories": {


### PR DESCRIPTION
- Travis should now automatically generate and update coverage report
- Remove old coveralls.yml file with Github token
- Should stop Travis from pushing to gh-pages branch