### PR TITLE
Closes #33: Remove object prototypes, use classes instead

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,10 +4,10 @@ var express = require('express'),
 	bodyParser = require('body-parser'),
 	app = express(),
 	strings = require('./res/strings-en.json'),
-	BackendModule = require('./src/backend-module.js')
+	backend = require('./src/backend-module.js')
 
 var last_updated = new Date(),
-    backendModule = new BackendModule()
+    backendModule = new backend.BackendModule()
 
 // Setup and start server
 app.set("port", (process.env.PORT || 3000))

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "module": "system",
+        "module": "es6",
         "allowSyntheticDefaultImports": true
     }
 }

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "chai": "4.1.2",
     "coveralls": "3.0.0",
     "heroku-cli-util": "6.2.10",
-    "mocha": "4.0.1",
     "istanbul": "0.4.5",
-    "sinon": "4.0.2",
-    "rewire": "2.5.2"
+    "mocha": "^4.0.1",
+    "rewire": "2.5.2",
+    "sinon": "4.0.2"
   },
   "directories": {
     "test": "test"

--- a/src/backend-module.js
+++ b/src/backend-module.js
@@ -12,18 +12,15 @@ const fbToken = process.env.FB_TOKEN,
  * @name BackendModule
  * @param {*} messengerUtilModule 
  */
-function BackendModule(
-    messengerUtilModule = new MessengerUtilModule()
-) {
-    this._util = messengerUtilModule
-}
-
-BackendModule.prototype = {
+export default class BackendModule {
+    constructor(messengerUtilModule=new MessengerUtilModule()) {
+        this._util = messengerUtilModule
+    }
     /**
      * Handles messaging events passed from Facebook
      * @param {List} messagingEvents
      */
-    handleMessagingEvents: function(messageEvents) {
+    handleMessagingEvents(messageEvents) {
         // get all events
         for (let i = 0; i < messageEvents.length; i++) {
             let event = messageEvents[i]
@@ -36,14 +33,14 @@ BackendModule.prototype = {
                 this._handlePostback(event)
             }
         }
-    },
+    }
 
     /**
      * Sets up and manages Host creation
      * @param {String} authenticationCode
      * @param {String} facebookId
      */
-    handleCreateHost: function(authenticationCode, facebookId, module=this) {
+    handleCreateHost(authenticationCode, facebookId, module=this) {
         // TODO: better code generation
         let passcode = facebookId.substring(4,8)
         
@@ -58,12 +55,12 @@ BackendModule.prototype = {
         }, function(err) {
             module._sendSingleMessage(facebookId, strings.spotifyConnectError)
         })
-    },
+    }
 
     /**
      * Prompts Facebook to activate a Get Started page
      */
-    setGetStarted: function() {
+    setGetStarted() {
         request({
             url: 'https://graph.facebook.com/v2.6/me/messenger_profile',
             qs: {access_token:fbToken},
@@ -82,9 +79,9 @@ BackendModule.prototype = {
                 console.log("Setting 'Get Started': ", response.body.result)
             }
         })
-    },
+    }
 
-    _handleMessage: function(event, module=this) {
+    _handleMessage(event, module=this) {
         if (event.message.is_echo === true) {
             return
         }
@@ -107,9 +104,9 @@ BackendModule.prototype = {
         setTimeout(function() {
             module._sendMultipleMessages(senderId, messageDataSeries, 0)
         }, 300)
-    },
+    }
 
-    _handlePostback: function(event, module=this) {
+    _handlePostback(event, module=this) {
         let load = JSON.parse(event.postback.payload),
             senderId = event.sender.id
         console.info("Postback received of type: " + JSON.stringify(load.type) + " from " + senderId)
@@ -161,9 +158,9 @@ BackendModule.prototype = {
                 module._sendSingleMessage(senderId, strings.responseUnknown)
                 break	
         }
-    },
+    }
 
-    _sendMultipleMessages: function(senderId, messages, position, module=this) {
+    _sendMultipleMessages(senderId, messages, position, module=this) {
         console.log("Sending series: " + messages)
         if (position < messages.length) {
             module._typingIndicator(senderId, true)
@@ -196,9 +193,9 @@ BackendModule.prototype = {
         } else {
             return
         }
-    },
+    }
 
-    _sendSingleMessage: function(senderId, message) {
+    _sendSingleMessage(senderId, message) {
         if ((typeof message) == "string") {
             message = {text:message}
         }
@@ -220,9 +217,9 @@ BackendModule.prototype = {
                 console.log("Message delivered: ", message)
             }
         })
-    },
+    }
 
-    _typingIndicator: function(senderId, status) {
+    _typingIndicator(senderId, status) {
         var state
         if (status) state = "on"
         else state = "off"
@@ -246,5 +243,3 @@ BackendModule.prototype = {
         })
     }
 }
-
-module.exports = BackendModule

--- a/src/backend-module.js
+++ b/src/backend-module.js
@@ -1,6 +1,6 @@
 var strings = require('../res/strings-en.json'),
     request = require('request'),
-    MessengerUtilModule = require('./facebook-messenger-utils.js')
+    messenger = require('./facebook-messenger-utils.js')
 
 const fbToken = process.env.FB_TOKEN,
     fbMessageApiUrl = "https://graph.facebook.com/v2.6/me/messages"
@@ -12,8 +12,8 @@ const fbToken = process.env.FB_TOKEN,
  * @name BackendModule
  * @param {*} messengerUtilModule 
  */
-export default class BackendModule {
-    constructor(messengerUtilModule=new MessengerUtilModule()) {
+class BackendModule {
+    constructor(messengerUtilModule=new messenger.MessengerUtilModule()) {
         this._util = messengerUtilModule
     }
     /**
@@ -243,3 +243,5 @@ export default class BackendModule {
         })
     }
 }
+
+module.exports = {BackendModule}

--- a/src/facebook-messenger-utils.js
+++ b/src/facebook-messenger-utils.js
@@ -8,42 +8,40 @@ var SpotifyModule = require('./spotify-module.js'),
  * @name MessengerUtilModule
  * @param {*} spotifyModule
  */
-function MessengerUtilModule(
-    spotifyModule = new SpotifyModule()
-) {
-    this._spotifyModule = spotifyModule
-    this._spotifyModule.setupCredentials()
+export default class MessengerUtilModule {
+    constructor(spotifyModule=new SpotifyModule()){
+        this._spotifyModule = spotifyModule
+        this._spotifyModule.setupCredentials()
 
-    /**
-     * Map of sender_id that the bot is waiting for a passphrase from
-     * - KEY: sender 
-     * - VAL: {songId, songName, artist, preview}
-     * @var {Map} songRequests
-     */
-    this._songRequests = new Map()
+        /**
+         * Map of sender_id that the bot is waiting for a passphrase from
+         * - KEY: sender 
+         * - VAL: {songId, songName, artist, preview}
+         * @var {Map} songRequests
+         */
+        this._songRequests = new Map()
 
-    /**
-     * Mapp of hosts and their associated passcodes and information
-     * - KEY: passcode
-     * - VAL: {fbId, spotifyId, playlistId, accessToken, refreshToken}
-     * @var {Map} hostList
-     */
-    this._hostList = new Map()
+        /**
+         * Mapp of hosts and their associated passcodes and information
+         * - KEY: passcode
+         * - VAL: {fbId, spotifyId, playlistId, accessToken, refreshToken}
+         * @var {Map} hostList
+         */
+        this._hostList = new Map()
 
-    // TODO: replace with postgresSQL database tables
-}
+        // TODO: replace with postgresSQL database tables
+    }
 
-MessengerUtilModule.prototype = {
     /**
      * Determines appropriate response message
      * @param {String} senderId 
      * @param {String} messageText
      * @return {Array} responseMessages
      */
-    responseBuilder: function(
+    responseBuilder(
         senderId, 
         messageText,
-        module = this
+        module=this
     ) {
         var keyword = messageText.toLowerCase()
         if (messageText.includes(" ")) {
@@ -62,16 +60,16 @@ MessengerUtilModule.prototype = {
             default:
                 return strings.responseDefault
         }
-    },
+    }
 
     /**
      * Determines appropriate response message
      * @param {String} senderId 
      * @param {Object} songRequest
      */
-    addSongRequest: function(senderId, songRequest) {
+    addSongRequest(senderId, songRequest) {
         this._songRequests.set(senderId, songRequest)
-    },
+    }
 
     /**
      * Checks if Facebook user has outstanding song request
@@ -79,10 +77,10 @@ MessengerUtilModule.prototype = {
      * @param {String} messageText
      * @return {Array} responseMessages of {senderId, responseMessage}
      */
-    handleOutstandingSongRequest: function(
+    handleOutstandingSongRequest(
         senderId, 
         messageText,
-        senderMessagePairMaker = this._senderMessagePairMaker
+        senderMessagePairMaker=this._senderMessagePairMaker
     ) {
         let songRequest = this.getSongRequest(senderId)
         let responseMessages = []
@@ -134,18 +132,18 @@ MessengerUtilModule.prototype = {
             ))
         }
         return responseMessages
-    },
+    }
 
     /**
      * Handles song request approval
      * @param {Object} approveSongRequestPayload 
      * @return {Promise} resolves to an array of messages
      */
-    handleApproveSongRequest: function(
+    handleApproveSongRequest(
         approveSongRequestPayload, 
-        spotifyModule = this._spotifyModule,
-        senderMessagePairMaker = this._senderMessagePairMaker,
-        hostList = this._hostList
+        spotifyModule=this._spotifyModule,
+        senderMessagePairMaker=this._senderMessagePairMaker,
+        hostList=this._hostList
     ) {
         let responseMessages = []
         let sender = approveSongRequestPayload.sender
@@ -177,14 +175,14 @@ MessengerUtilModule.prototype = {
                     resolve(responseMessages)
                 })
         })
-    },
+    }
 
     /**
      * Assembles response message for audio attachment
      * @param {String} link
      * @return {Object} messageData
      */
-    audioAttachmentResponse: function(link) {
+    audioAttachmentResponse(link) {
         let messageData = {
             "attachment": {
                 "type": "audio",
@@ -194,26 +192,26 @@ MessengerUtilModule.prototype = {
             }
         }
         return(messageData)
-    },
+    }
 
     /**
      * Adds host and host data to hostList
      * @param {String} passcode
      * @param {Object} hostData
      */
-    addHost: function(passcode, hostData) {
+    addHost(passcode, hostData) {
         this._hostList.set(passcode, hostData)
-    },
+    }
 
     /**
      * Creates 
      * @param {String} authenticationCode
      * @param {String} facebookId
      */
-    createHost: function(
+    createHost(
         authenticationCode, 
         facebookId, 
-        spotifyModule = this._spotifyModule
+        spotifyModule=this._spotifyModule
     ) {
         return new Promise(function(resolve,reject) {
             spotifyModule.createHost(authenticationCode, facebookId)
@@ -224,31 +222,31 @@ MessengerUtilModule.prototype = {
                 }
             )
         })
-    },
+    }
 
     /**
      * Checks if sender has an outstanding song request
      * @param {String} senderId
      * @return {Boolean} hasSongRequest
      */
-    hasSongRequest: function(senderId) {
+    hasSongRequest(senderId) {
         if (this._songRequests.get(senderId)) {
             return true
         } else { 
             return false
         }
-    },
+    }
 
     /**
      * Retrieves SongRequest by senderId
      * @param {String} senderId
      * @return {Boolean} hasSongRequest
      */
-    getSongRequest: function(senderId) {
+    getSongRequest(senderId) {
         return this._songRequests.get(senderId)
-    },
+    }
 
-    _loginResponse: function(senderId, spotifyModule = this._spotifyModule) {
+    _loginResponse(senderId, spotifyModule=this._spotifyModule) {
         var scopes = [
             'user-read-private',
             'playlist-read-collaborative', 
@@ -281,12 +279,12 @@ MessengerUtilModule.prototype = {
         }
         messageSeries.push(buttonTemplate)
         return messageSeries
-    },
+    }
 
-    _searchResponse: function(
+    _searchResponse(
         messageText, 
-        spotifyModule = this._spotifyModule,
-        assembleSearchResponse = this._assembleSearchResponse
+        spotifyModule=this._spotifyModule,
+        assembleSearchResponse=this._assembleSearchResponse
     ) {
         var searchTerm = messageText.substring(6,200) // exclude word "search"
 
@@ -307,9 +305,9 @@ MessengerUtilModule.prototype = {
             })
         
         return messageSeries
-    },
+    }
 
-    _assembleSearchResponse: function(searchResultData) {
+    _assembleSearchResponse(searchResultData) {
         let messageSeries = []
 
         var songTracks = searchResultData.body.tracks.items
@@ -361,14 +359,12 @@ MessengerUtilModule.prototype = {
         messageSeries.push(strings.searchResultFound)
         messageSeries.push(messageData)
         return messageSeries	
-    },
+    }
 
-    _senderMessagePairMaker: function(senderId, messageContent) {
+    _senderMessagePairMaker(senderId, messageContent) {
         return {
             senderId:senderId,
             messageContent:messageContent
         }
     }
 }
-
-module.exports = MessengerUtilModule

--- a/src/facebook-messenger-utils.js
+++ b/src/facebook-messenger-utils.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var SpotifyModule = require('./spotify-module.js'),
+var spotify = require('./spotify-module.js'),
     strings = require('../res/strings-en.json')
 
 /**
@@ -8,8 +8,8 @@ var SpotifyModule = require('./spotify-module.js'),
  * @name MessengerUtilModule
  * @param {*} spotifyModule
  */
-export default class MessengerUtilModule {
-    constructor(spotifyModule=new SpotifyModule()){
+class MessengerUtilModule {
+    constructor(spotifyModule=new spotify.SpotifyModule()){
         this._spotifyModule = spotifyModule
         this._spotifyModule.setupCredentials()
 
@@ -368,3 +368,5 @@ export default class MessengerUtilModule {
         }
     }
 }
+
+module.exports = {MessengerUtilModule}

--- a/src/spotify-module.js
+++ b/src/spotify-module.js
@@ -8,7 +8,7 @@ var SpotifyWebApi = require("spotify-web-api-node")
  * Provides access to Spotify API via spotify-web-api-node
  * @name SpotifyModule
  */
-export default class SpotifyModule {
+class SpotifyModule {
     constructor(
         spotifyApi=new SpotifyWebApi({
             clientId:process.env.SPOTIFY_CLIENT_ID,
@@ -134,3 +134,5 @@ export default class SpotifyModule {
         })
     }
 }
+
+module.exports = {SpotifyModule}

--- a/src/spotify-module.js
+++ b/src/spotify-module.js
@@ -8,20 +8,18 @@ var SpotifyWebApi = require("spotify-web-api-node")
  * Provides access to Spotify API via spotify-web-api-node
  * @name SpotifyModule
  */
-function SpotifyModule(
-    spotifyApi = new SpotifyWebApi({
-        clientId : process.env.SPOTIFY_CLIENT_ID,
-        clientSecret : process.env.SPOTIFY_CLIENT_SECRET,
-        redirectUri : process.env.SPOTIFY_REDIRECT_URI
-    })
-) {
-    this._spotifyApi = spotifyApi
-}
+export default class SpotifyModule {
+    constructor(
+        spotifyApi=new SpotifyWebApi({
+            clientId:process.env.SPOTIFY_CLIENT_ID,
+            clientSecret:process.env.SPOTIFY_CLIENT_SECRET,
+            redirectUri:process.env.SPOTIFY_REDIRECT_URI
+        })
+    ){
+        this._spotifyApi = spotifyApi
+    }
 
-SpotifyModule.prototype = {
-    setupCredentials: function(
-        module = this
-    ) {
+    setupCredentials(module=this) {
         this._spotifyApi.clientCredentialsGrant()
         .then(function(data) {
             console.log("Spotify access token request success!")
@@ -31,7 +29,7 @@ SpotifyModule.prototype = {
         }).catch(function(err) {
             console.error("Spotify access token request error", err)
         })
-    },
+    }
 
     /**
      * Request auth codes, get user info, create playlist, save everything, set auth back to client
@@ -39,11 +37,11 @@ SpotifyModule.prototype = {
      * @param {String} facebookId
      * @return {Promise} hostData
      */
-    createHost: function(
+    createHost(
         authenticationCode, 
         facebookId, 
-        spotifyApi = this._spotifyApi,
-        spotifyClientAccessToken = this._spotifyClientAccessToken
+        spotifyApi=this._spotifyApi,
+        spotifyClientAccessToken=this._spotifyClientAccessToken
     ) {
         return new Promise(function(resolve, reject) {
             spotifyApi.authorizationCodeGrant(authenticationCode)
@@ -80,7 +78,7 @@ SpotifyModule.prototype = {
                     reject(err)
                 })
         })
-    },
+    }
 
     /**
      * Creates URL for users to authenticate
@@ -88,22 +86,18 @@ SpotifyModule.prototype = {
      * @param {String} state
      * @return {String} authorizeUrl
      */
-    createAuthLink: function(
-        scopes,
-        state,
-        spotifyApi = this._spotifyApi
-    ) {
+    createAuthLink(scopes,state,spotifyApi=this._spotifyApi) {
         return spotifyApi.createAuthorizeURL(scopes, state)
-    },
+    }
 
     /**
      * Conducts Spotify search
      * @param {String} searchTerm 
      * @return {Object} searchResultData
      */
-    search: function(searchTerm, spotifyApi = this._spotifyApi) {
+    search(searchTerm, spotifyApi=this._spotifyApi) {
         return spotifyApi.searchTracks(searchTerm)
-    },
+    }
 
     /**
      * Approves song request
@@ -111,11 +105,11 @@ SpotifyModule.prototype = {
      * @param {String} songId
      * @return {Promise} songRequestApprovalSuccess
      */
-    approveSongRequest: function(
+    approveSongRequest(
         host, 
         songId, 
-        spotifyApi = this._spotifyApi, 
-        spotifyClientAccessToken = this._spotifyClientAccessToken
+        spotifyApi=this._spotifyApi, 
+        spotifyClientAccessToken=this._spotifyClientAccessToken
     ) {
         return new Promise(function(resolve, reject) {
             // set auth to user, refresh token, add to playlist, set auth back to client
@@ -140,5 +134,3 @@ SpotifyModule.prototype = {
         })
     }
 }
-
-module.exports = SpotifyModule

--- a/test/backend-module-test.js
+++ b/test/backend-module-test.js
@@ -5,10 +5,10 @@ var assert = require('assert'),
     sinon = require('sinon'),
     strings = require('../res/strings-en.json')
 
-var BackendModule = require('../src/backend-module.js'),
-    MessengerUtilModule = require('../src/facebook-messenger-utils.js'),
-    SpotifyModule = require('../src/spotify-module.js'),
-    SpotifyWebApi = require("spotify-web-api-node")
+var backendModule = require('../src/backend-module.js'),
+    messenger = require('../src/facebook-messenger-utils.js'),
+    spotify = require('../src/spotify-module.js'),
+    spotifyApi = require("spotify-web-api-node")
 
 describe("Backend module", function() {
     var setupStub,
@@ -16,13 +16,13 @@ describe("Backend module", function() {
         backend
 
     beforeEach(function() {
-        var spotifyApiStub = sinon.createStubInstance(SpotifyWebApi)
-        setupStub = sinon.stub(SpotifyModule.prototype, 'setupCredentials').callsFake(
+        var spotifyApiStub = sinon.createStubInstance(spotifyApi)
+        setupStub = sinon.stub(spotify.SpotifyModule.prototype, 'setupCredentials').callsFake(
             function fakeSetup() {}
         )
-        var spotifyModule = new SpotifyModule(spotifyApiStub)
-        var util = new MessengerUtilModule(spotifyModule)
-        backend = new BackendModule(util)
+        var spotifyModule = new spotify.SpotifyModule(spotifyApiStub)
+        var util = new messenger.MessengerUtilModule(spotifyModule)
+        backend = new backendModule.BackendModule(util)
     })
 
     afterEach(function() {

--- a/test/facebook-messenger-utils-test.js
+++ b/test/facebook-messenger-utils-test.js
@@ -5,7 +5,7 @@ var assert = require('assert'),
     sinon = require('sinon'),
     strings = require('../res/strings-en.json')
 
-var MessengerUtilModule = require('../src/facebook-messenger-utils.js'),
+var MessengerModule = require('../src/facebook-messenger-utils.js'),
     SpotifyModule = require('../src/spotify-module.js'),
     SpotifyWebApi = require("spotify-web-api-node")
 
@@ -18,11 +18,11 @@ describe("Facebook Messenger Util module", function() {
 
     beforeEach(function() {
         spotifyApiStub = sinon.createStubInstance(SpotifyWebApi)
-        setupStub = sinon.stub(SpotifyModule.prototype, 'setupCredentials').callsFake(
+        setupStub = sinon.stub(SpotifyModule.SpotifyModule.prototype, 'setupCredentials').callsFake(
             function fakeSetup() {}
         )
-        var spotifyModule = new SpotifyModule(spotifyApiStub)
-        util = new MessengerUtilModule(spotifyModule)
+        var spotifyModule = new SpotifyModule.SpotifyModule(spotifyApiStub)
+        util = new MessengerModule.MessengerUtilModule(spotifyModule)
     })
 
     afterEach(function() {
@@ -54,7 +54,7 @@ describe("Facebook Messenger Util module", function() {
 
         describe("when 'Search' is 1st term", function(done) {
             it('when phrase is 2nd, should songs as messages in correct format', function(done) {
-                var searchStub = sinon.stub(SpotifyModule.prototype, 'search').callsFake(
+                var searchStub = sinon.stub(SpotifyModule.SpotifyModule.prototype, 'search').callsFake(
                     function fakeSearch(t) {
                         return new Promise(function(resolve, reject) {
                             resolve(searchData3Songs)
@@ -100,7 +100,7 @@ describe("Facebook Messenger Util module", function() {
             })
     
             it('when phrase is 2nd, should not send more than 7 songs', function(done) {
-                var searchStub = sinon.stub(SpotifyModule.prototype, 'search').callsFake(
+                var searchStub = sinon.stub(SpotifyModule.SpotifyModule.prototype, 'search').callsFake(
                     function fakeSearch(t) {
                         return new Promise(function(resolve, reject) {
                             resolve(searchData10Songs)
@@ -120,7 +120,7 @@ describe("Facebook Messenger Util module", function() {
             })
     
             it('when phrase is 2nd and no songs found, should return message', function(done) {
-                var searchStub = sinon.stub(SpotifyModule.prototype, 'search').callsFake(
+                var searchStub = sinon.stub(SpotifyModule.SpotifyModule.prototype, 'search').callsFake(
                     function fakeSearch(t) {
                         return new Promise(function(resolve, reject) {
                             var noSongsResult = {}
@@ -149,7 +149,7 @@ describe("Facebook Messenger Util module", function() {
 
         describe("when 'Host' is first term", function(done) {
             it('create a login link', function(done){
-                var authMakerStub = sinon.stub(SpotifyModule.prototype, 'createAuthLink').callsFake(
+                var authMakerStub = sinon.stub(SpotifyModule.SpotifyModule.prototype, 'createAuthLink').callsFake(
                     function fakeSearch(scopes, senderId) {
                         return "http://www.google.com/"
                     }
@@ -269,7 +269,7 @@ describe("Facebook Messenger Util module", function() {
         }
 
         it('when song request is approved, notify users and call SpotifyModule.approveSongRequest', function(done) {
-            var approveStub = sinon.stub(SpotifyModule.prototype, 'approveSongRequest').callsFake(
+            var approveStub = sinon.stub(SpotifyModule.SpotifyModule.prototype, 'approveSongRequest').callsFake(
                 function fakeApprove(h, id) {
                     return new Promise(function(resolve, reject) {
                         resolve()
@@ -289,7 +289,7 @@ describe("Facebook Messenger Util module", function() {
         })
 
         it('when song request approval errors out, notify users', function(done) {
-            var approveStub = sinon.stub(SpotifyModule.prototype, 'approveSongRequest').callsFake(
+            var approveStub = sinon.stub(SpotifyModule.SpotifyModule.prototype, 'approveSongRequest').callsFake(
                 function fakeApprove(h, id) {
                     return new Promise(function(resolve, reject) {
                         reject("Bad thing happened")
@@ -313,7 +313,7 @@ describe("Facebook Messenger Util module", function() {
 
     describe("createHost(...)", function() {
         it('Host creation calls SpotifyModule', function(done) {
-            var createHostStub = sinon.stub(SpotifyModule.prototype, 'createHost').callsFake(
+            var createHostStub = sinon.stub(SpotifyModule.SpotifyModule.prototype, 'createHost').callsFake(
                 function fakeCreate(a, id) {
                     return new Promise(function(resolve, reject) {
                         resolve({


### PR DESCRIPTION
## Issues
#33 

## Description
- Get ride of object prototypes (ew) and use clean proper ES6 classes instead
- Update tests and mocks accordingly

Node doesn't seem to support `import ... from ...` yet so sticking with `require` for now